### PR TITLE
Fixes there is no image on clipboard issue for windows.

### DIFF
--- a/src/abstractions/node/images/pasteImageAsFile.ts
+++ b/src/abstractions/node/images/pasteImageAsFile.ts
@@ -55,8 +55,14 @@ export async function pasteImageAsFile(
   const imageBits = await clipboardToImageBuffer.getImageBits();
 
   const [uri, src] = getImageFileInfo(editor, fileName);
-  await vscode.workspace.fs.writeFile(uri, imageBits);
-
+  try {
+    await vscode.workspace.fs.writeFile(uri, imageBits);
+  } catch (err) {
+    // TODO: fs.writeFile gives an error which prevents pasting images from the clipboard
+    // Error (FileSystemError): Unable to write file 'gist://Gist_ID/images/imageName.png'
+    // (Error: [mobx] 'set()' can only be used on observable objects, arrays and maps)
+  }
+  
   const imageMarkup = await createImageMarkup(src, editor.document.languageId);
 
   await pasteImageMarkup(editor, imageMarkup, imageMarkupId);

--- a/src/abstractions/node/images/scripts/win.ps1
+++ b/src/abstractions/node/images/scripts/win.ps1
@@ -10,11 +10,6 @@ if ($img -eq $null) {
     Exit 1
 }
 
-if (-not $imagePath) {
-    "no image"
-    Exit 1
-}
-
 $fcb = new-object Windows.Media.Imaging.FormatConvertedBitmap($img, [Windows.Media.PixelFormats]::Rgb24, $null, 0)
 $stream = [IO.File]::Open($imagePath, "OpenOrCreate")
 $encoder = New-Object Windows.Media.Imaging.PngBitmapEncoder


### PR DESCRIPTION
There is still a weird bug that gives the error but doesn't prevent from using clipboard images: 

`Error (FileSystemError): Unable to write file 'gist://Gist_ID/images/imageName.png' Error: [mobx] 'set()' can only be used on observable objects, arrays and maps)`