### PR TITLE
Update icons in Showcase view

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,10 +412,7 @@
       {
         "command": "gistpad.refreshShowcase",
         "title": "Refresh Showcase",
-        "icon": {
-          "dark": "images/dark/refresh.svg",
-          "light": "images/light/refresh.svg"
-        }
+        "icon": "$(refresh)"
       },
       {
         "command": "gistpad.renameDirectory",


### PR DESCRIPTION
**This PR fixes Issue#**
Fix this issue: #255 

**Description of the PR**:
Use `$(refresh)` for the Refresh icon in Showcase view, as in the other views


**Additional context**:

