### PR TITLE
Support GitHub default branch in Repositories

### DIFF
--- a/src/repos/store/actions.ts
+++ b/src/repos/store/actions.ts
@@ -180,11 +180,12 @@ export async function getRepo(
     );
 
     if (response.statusCode === 200) {
-      return [response.body, response.headers.etag];
+      return [response.body, response.rawHeaders[13]]; // response.rawHeaders[13] is etag
     } else {
       return [];
     }
   } catch (e) {
+    console.log(e);
     // If the repo is empty (i.e. it has no files yet), then
     // the call to get the tree will return a 409.
     // TODO: Indicate when the repository has been
@@ -529,7 +530,7 @@ export async function updateRepoFile(
       );
     } else {
       vscode.window.showInformationMessage(
-        "Can't save this file to do an unresoveable conflict with the remote repository."
+        "Can't save this file to do an unresolvable conflict with the remote repository."
       );
     }
   }

--- a/src/repos/store/actions.ts
+++ b/src/repos/store/actions.ts
@@ -161,7 +161,17 @@ export async function getRepoFile(
   const api = await getApi(GitHub);
 
   const response = await api.get(`/repos/${repo}/git/blobs/${sha}`);
-  return base64ToUintArray(response.body.content);
+
+  return new Uint8Array(
+    Buffer.from(response.body.content, "base64")
+      .toString("latin1")
+      .split("")
+      .map(charCodeAt)
+  );
+}
+
+function charCodeAt(c: string) {
+  return c.charCodeAt(0);
 }
 
 export async function getRepo(

--- a/src/repos/store/actions.ts
+++ b/src/repos/store/actions.ts
@@ -206,15 +206,15 @@ export async function getDefaultBranch(repoName: string) {
   const GitHub = require("github-base");
   const api = await getApi(GitHub);
 
-  let default_branch = "master";
+  let defaultBranch = "master";
   try {
     const response = await api.get(`/repos/${repoName}`);
-    default_branch = response.body.default_branch;
+    defaultBranch = response.body.default_branch;
   } catch (e) {
     console.log(`Gistpad: cannot get default branch for ${repoName}`);
   }
 
-  return default_branch;
+  return defaultBranch;
 }
 
 export async function listRepos() {
@@ -330,8 +330,8 @@ export async function updateBranch(repo: string, branch: string, sha: string) {
 
 export async function openRepo(repoName: string, showReadme: boolean = false) {
   // TODO: Add repo validation
-  const default_branch = await getDefaultBranch(repoName);
-  const repository = new Repository(repoName, default_branch);
+  const defaultBranch = await getDefaultBranch(repoName);
+  const repository = new Repository(repoName, defaultBranch);
 
   const repos = storage.repos;
   if (repos.find((repo) => repo === repository.name)) {
@@ -407,11 +407,9 @@ export async function refreshRepositories() {
     clearInterval(refreshTimer);
   }
 
-  store.repos = storage.repos.map((repo) => new Repository(repo));
-
   store.repos = await Promise.all(
     storage.repos.map(async (repo) => {
-      let defaultBranch = await getDefaultBranch(repo);
+      const defaultBranch = await getDefaultBranch(repo);
       return new Repository(repo, defaultBranch);
     })
   );

--- a/src/repos/store/actions.ts
+++ b/src/repos/store/actions.ts
@@ -9,8 +9,6 @@ import { focusRepo } from "../tree";
 import { sanitizeName } from "../utils";
 import { updateTree } from "../wiki/actions";
 
-const base64ToUintArray = require("base64-to-uint8array");
-
 export async function addRepoFile(
   repoName: string,
   branch: string,

--- a/src/repos/store/index.ts
+++ b/src/repos/store/index.ts
@@ -1,5 +1,6 @@
 import { computed, observable } from "mobx";
 import * as path from "path";
+// import { getApi } from "src/store/actions";
 import { CommentThread, Location, Uri } from "vscode";
 import { SWING_FILE } from "../../constants";
 import { GistComment, store as mainStore } from "../../store";
@@ -109,14 +110,14 @@ export class Repository {
   name: string;
   branch: string;
 
-  constructor(public fullName: string) {
+  constructor(public fullName: string, public defaultBranch?: string) {
     if (this.fullName.includes("#")) {
       const parts = this.fullName.split("#");
       this.name = parts[0];
       this.branch = parts[1];
     } else {
       this.name = fullName;
-      this.branch = Repository.DEFAULT_BRANCH;
+      defaultBranch ? this.branch = defaultBranch : this.branch = Repository.DEFAULT_BRANCH;
     }
   }
 

--- a/src/repos/store/index.ts
+++ b/src/repos/store/index.ts
@@ -1,6 +1,5 @@
 import { computed, observable } from "mobx";
 import * as path from "path";
-// import { getApi } from "src/store/actions";
 import { CommentThread, Location, Uri } from "vscode";
 import { SWING_FILE } from "../../constants";
 import { GistComment, store as mainStore } from "../../store";

--- a/src/repos/tree/index.ts
+++ b/src/repos/tree/index.ts
@@ -61,7 +61,7 @@ class RepositoryTreeProvider implements TreeDataProvider<TreeItem> {
   getChildren(element?: TreeItem): ProviderResult<TreeItem[]> {
     if (!element && authStore.isSignedIn && store.repos.length > 0) {
       return store.repos
-        .sort((a, b) => a.name.localeCompare(b.name))
+        .slice().sort((a, b) => a.name.localeCompare(b.name))
         .map((repo) => new RepositoryNode(repo));
     } else if (element instanceof RepositoryNode) {
       if (element.repo.isLoading) {

--- a/src/repos/tree/nodes.ts
+++ b/src/repos/tree/nodes.ts
@@ -21,9 +21,10 @@ export class RepositoryNode extends TreeItem {
       this.description = "Primary";
     }
 
-    this.contextValue += ".branch";
-    this.description = repo.branch;
-
+    if (repo.branch !== Repository.DEFAULT_BRANCH) {
+      this.contextValue += ".branch";
+      this.description = repo.branch;
+    }
     if (repo.hasTours) {
       this.contextValue += ".hasTours";
     }

--- a/src/repos/tree/nodes.ts
+++ b/src/repos/tree/nodes.ts
@@ -21,17 +21,15 @@ export class RepositoryNode extends TreeItem {
       this.description = "Primary";
     }
 
-    if (repo.branch !== Repository.DEFAULT_BRANCH) {
-      this.contextValue += ".branch";
-      this.description = repo.branch;
-    }
+    this.contextValue += ".branch";
+    this.description = repo.branch;
 
     if (repo.hasTours) {
       this.contextValue += ".hasTours";
     }
 
-    this.tooltip = `Repo: ${repo.name}
-Branch: ${repo.branch}`;
+    this.tooltip = `Repo: ${repo.name};
+    Branch: ${repo.branch}`;
   }
 }
 


### PR DESCRIPTION
**Description of the PR**:
Problem: currently, if a repo default branch is anything other than "master", the Repositories view cannot show the repo content.
This change adds the ability to read a repo default branch from GitHub and use it to display its content as expected.

_Note: this branch also contains the fix #278, this change would not make sense without that fix because Repositories is unable to show any content, regardless of the default branch used._

**Additional context**:

![image](https://user-images.githubusercontent.com/5784415/163304293-c68ebe61-cc9c-4a5e-9433-9818bd7fff80.png)
