### PR TITLE
Retrieve all Gists for followed users with more than 100

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,12 @@
-name: Publish to VSCode Marketplace
+name: Release
 
 on:
-  workflow_dispatch:
+  release:
+    types:
+      - created
 
-  push:
-    branches:
-      - master
-    tags:
-      - "*"
-  
 jobs:
-  deploy:
+  Release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,7 +16,7 @@ jobs:
         with:
           node-version: 14.x
       - run: npm install
-      - name: Publish to VSCode Marketplace
+      - name: Publish to VS Marketplace
         run: npx vsce publish
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
-name: Release
+name: Publish to VSCode Marketplace
 
 on:
-  release:
-    types:
-      - created
+  workflow_dispatch:
 
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  
 jobs:
-  Release:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,7 +20,7 @@ jobs:
         with:
           node-version: 14.x
       - run: npm install
-      - name: Publish to VS Marketplace
+      - name: Publish to VSCode Marketplace
         run: npx vsce publish
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/src/repos/store/actions.ts
+++ b/src/repos/store/actions.ts
@@ -188,7 +188,8 @@ export async function getRepo(
     );
 
     if (response.statusCode === 200) {
-      return [response.body, response.rawHeaders[13]]; // response.rawHeaders[13] is etag
+      let eTagIndex = response.rawHeaders.indexOf("ETag") + 1;
+      return [response.body, response.rawHeaders[eTagIndex]];
     } else {
       return [];
     }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -203,6 +203,7 @@ export async function listUserGists(username: string): Promise<Gist[]> {
   let page = 1;
   let responseBody: any[] = [];
   let getNextPage = true;
+  let linkIndex = 0;
 
   while (getNextPage) {
     const response = await api.get(
@@ -217,8 +218,9 @@ export async function listUserGists(username: string): Promise<Gist[]> {
 
     page++;
 
-    let linkIndex = response.rawHeaders[23].indexOf('rel="next"'); // Link header starts at index 23
-    if (linkIndex === -1) {
+    linkIndex = response.rawHeaders.indexOf("Link") + 1;
+    let nextIndex = response.rawHeaders[linkIndex].indexOf('rel="next"');
+    if (nextIndex === -1) {
       getNextPage = false;
     }
   }


### PR DESCRIPTION
**Description of the PR**:
Currently, gists for Followed Users is capped to 100; this PR allows to retrieve all gists for each Followed Users


**Additional context**:

Current behavior:

![image](https://user-images.githubusercontent.com/5784415/163734741-aaaaf2d2-bba1-48b2-b325-d2965921857b.png)

New behavior:

![image](https://user-images.githubusercontent.com/5784415/163734767-e6819fe0-9913-44a5-b21e-d66db8b0fe67.png)
