### PR TITLE
Fix paste gist file editor's action

### DIFF
--- a/src/commands/editor.ts
+++ b/src/commands/editor.ts
@@ -2,7 +2,6 @@ import { pasteImageCommand } from "@abstractions/images/pasteImage";
 import * as path from "path";
 import {
   commands,
-  env,
   ExtensionContext,
   ProgressLocation,
   TextEditor,
@@ -204,8 +203,9 @@ export function registerEditorCommands(context: ExtensionContext) {
         const uri = fileNameToUri(gist!.id, selectedFile);
         const contents = byteArrayToString(await workspace.fs.readFile(uri));
 
-        await env.clipboard.writeText(contents);
-        await commands.executeCommand("editor.action.clipboardPasteAction");
+        editor.edit((editBuilder) => {
+          editBuilder.insert(editor.selection.active, contents);
+        });
       }
     )
   );


### PR DESCRIPTION
**Description of the PR**:
Insert text in the editor view using the dedicated vscode api instead of using copy and paste from the clipboard.

**Additional context**:
This fixes the behavior on macOS and maybe other platforms.