### PR TITLE
change to make file upload work with Remote-WSL

### DIFF
--- a/src/commands/file.ts
+++ b/src/commands/file.ts
@@ -216,11 +216,11 @@ export function registerFileCommands(context: ExtensionContext) {
             Promise.all(
               files.map(async (file) => {
                 const fileName = path.basename(file.path);
-                const content = workspace.fs.readFile(file);
+                const content = await workspace.fs.readFile(file);
 
                 return workspace.fs.writeFile(
                   fileNameToUri(node.gist.id, fileName),
-                  await content
+                  content
                 );
               })
             )

--- a/src/commands/file.ts
+++ b/src/commands/file.ts
@@ -1,6 +1,4 @@
-import * as fs from "fs";
 import * as path from "path";
-import { URL } from "url";
 import {
   commands,
   env,
@@ -212,16 +210,17 @@ export function registerFileCommands(context: ExtensionContext) {
           openLabel: "Upload"
         });
 
+
         if (files) {
           withProgress("Uploading file(s)...", () =>
             Promise.all(
-              files.map((file) => {
+              files.map(async (file) => {
                 const fileName = path.basename(file.path);
-                const content = fs.readFileSync(new URL(file.toString()));
+                const content = workspace.fs.readFile(file);
 
                 return workspace.fs.writeFile(
                   fileNameToUri(node.gist.id, fileName),
-                  content
+                  await content
                 );
               })
             )


### PR DESCRIPTION
**This PR fixes Issue #221 **


**Description of the PR**:
Since addFilesToGist works but uploadFileToGist does not I compared their code. The obvious difference is that add is just using readFile while update is using readFileSync. Making a guess there is an issue with the blocking synchronous read I modified uploadFileToGist to use just readFile, built a new .vsix and tested it. The upload works succesfully with my change.


**Additional context**:
This change was tested and confirmed to work with the following components working both locally and with a Remote-WSL connection:

Windows 10 21H2 (OS Build 19044.1766)
WSL distribution: Ubuntu 22.04 LTS (Linux Ubuntu-2204 5.10.102.1-microsoft-standard-WSL2)
VS Code version: 1.68.1
GistPad extension version: v0.4.1
Remote - WSL extenstion version: v0.66.3
