### PR TITLE
Fix_128

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,12 @@
-name: Publish to VSCode Marketplace
+name: Release
 
 on:
-  workflow_dispatch:
+  release:
+    types:
+      - created
 
-  push:
-    branches:
-      - master
-    tags:
-      - "*"
-  
 jobs:
-  deploy:
+  Release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,7 +16,7 @@ jobs:
         with:
           node-version: 14.x
       - run: npm install
-      - name: Publish to VSCode Marketplace
+      - name: Publish to VS Marketplace
         run: npx vsce publish
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
-name: Release
+name: Publish to VSCode Marketplace
 
 on:
-  release:
-    types:
-      - created
+  workflow_dispatch:
 
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  
 jobs:
-  Release:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,7 +20,7 @@ jobs:
         with:
           node-version: 14.x
       - run: npm install
-      - name: Publish to VS Marketplace
+      - name: Publish to VSCode Marketplace
         run: npx vsce publish
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,6 +175,10 @@ export async function openGistFiles(id: string) {
 }
 
 export async function openGistFile(uri: Uri, allowPreview: boolean = true) {
+  const rawUrlParts = uri.toString()?.split("/");
+  const rawFileName = rawUrlParts![rawUrlParts!.length - 1];
+
+  uri = fileNameToUri(uri.authority, rawFileName);
   commands.executeCommand("vscode.open", uri, {
     preview: true,
     viewColumn: ViewColumn.Active


### PR DESCRIPTION
**This PR fixes Issue#**
Fix for issue #128:  Unable to open Gist file with backslash in the filename


**Description of the PR**:
The `uri.path` value passed from `openFistFile` (file.ts:164) is json escaped but needs to be HTML encoded; since it is not, vscode fails to find the file and throws the exception described in the issue. 

**Additional context**:
Here are the two `uri` objects as an example, note the different `path` value

broken:
```json
{
  scheme: "gist",
  authority: "7beed6d4b22a859f2fabc028c2d6dbe5",
  path: "/History\\-258baa23\\entries.json",
  query: "",
  fragment: "",
  _formatted: null,
  _fsPath: null,
}
```

working:
```json
{
  scheme: "gist",
  authority: "7beed6d4b22a859f2fabc028c2d6dbe5",
  path: "/History%5C-258baa23%5Centries.json",
  query: "",
  fragment: "",
  _formatted: null,
  _fsPath: null,
}
```