### PR TITLE
Adding to ReadMe, Contributing, and CoC documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,53 @@
 
 # Microsoft Open Source Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+This code of conduct outlines expectations for participation in Microsoft-managed open source communities, as well as steps for reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all. People violating this code of conduct may be banned from the community.
 
-Resources:
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
-- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Disruptive behavior
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+## Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+This Code of Conduct also applies to actions taken outside of these spaces, and which have a negative impact on community health.
+
+## Enforcement and Reporting
+We encourage all communities to resolve issues on their own whenever possible. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opencode@microsoft.com.
+
+Your report will be handled in accordance with the issue resolution process described in the Code of Conduct FAQ. All project and community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct enforcement ladder.
+
+Expanding scope to include external impact on community health inspired by Facebook's Open Source Code of Conduct and Mozilla's Community Participation Guidelines.
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ The goal of this documentation is to provide a high-level overview of how you ca
   - [Run](#run)
   - [Debug](#debug)
   - [Sideload](#sideloading-the-extension)
-- **[Submit your change for review](#submit-your-change-for-review)
+- **[Submit your change for review](#submit-your-change-for-review)**
 
 ## Before you start coding
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,34 @@
 
-# Contributing to GistPad Project
+# Contributing to GistPad
 
 Thank you for your interest in contributing to GistPad! 
 
-The goal of this documentation is to provide a high-level overview of how you can build and debug the project. 
+The goal of this documentation is to provide a high-level overview of how you can build and debug the project. This guide will explain the process of setting up your development environment to work on the Gistpad extension, as well as the process of sending out your change for review.
 
+## Table of Contents
 
-# Building, Debugging and Sildeloading the extension in Visual Studio Code:
+- **[Before you start coding](#before-you-start-coding)**
+- **[Developing](#developing)**
+  - [Setup](#setup)
+  - [Run](#run)
+  - [Debug](#debug)
+  - [Sideload](#sideloading-the-extension)
+- **[Submit your change for review](#submit-your-change-for-review)
 
-## Building and Debugging the extension
+## Before you start coding
 
-Ensure you have [node](https://nodejs.org/en/) installed.
-Clone the repo, run `npm install` and open a development instance of Code.
+If you are interested in fixing a bug or contributing a feature, please [file an issue first](https://github.com/lostintangent/gistpad/issues/new/choose). Wait for a project maintainer to respond before you spend time coding.
+
+If you wish to work on an existing issue, please add a comment saying so, as someone may already be working on it. A project maintainer may respond with advice on how to get started. If you're not sure which issues are available, search for issues with the help wanted label.
+
+## Developing
+
+### Setup
+
+1. Ensure you have [node](https://nodejs.org/en/) installed.
+- Note: make sure that you are using npm v7 or higher. The file format for package-lock.json [changed significantly](https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#file-format) in npm v7.
+
+2. Clone the repository, run `npm install`, and open a development instance of VS Code:
 
 ```bash
 git clone https://github.com/vsls-contrib/gistpad.git 
@@ -22,11 +39,26 @@ code .
 
 You can now go to the Debug viewlet (`Ctrl+Shift+D`) and select `Run Extension (watch)` then hit run (`F5`).
 
-This will open a new VS Code window which will have the title `[Extension Development Host]`. In this window, open the GistPad tab from the sidebar. 
+#### Lint
+
+You can run `npm run lint` on the command-line to check for lint errors in your program. You can also use the [TSLint](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) plugin to see errors as you code.
+
+### Run
+
+To run the extension with your patch, open the Run view (`Ctrl+Shift+D` or `⌘+⇧+D`), select Launch Extension, and click Run (`F5`).
+
+This will open a new VS Code window with the title `[Extension Development Host]`.  In this window, open the GistPad tab from the sidebar. 
+
+### Debug
+
+You can go to the Debug viewlet (`Ctrl+Shift+D`) and select `Run Extension (watch)` then hit run (`F5`). 
+
+If you make subsequent edits in the codebase, you can reload (`Ctrl+R` or `⌘+R`) the `[Extension Development Host]` instance of VS Code, which will load the new code. The debugger will automatically reattach.
 
 In the original VS Code window, you can now add breakpoints which will be hit when you use any of the the plugin's features in the second window.
 
 ## Sideloading the extension
+
 After making changes to the extension, you might want to test it end to end instead of running it in debug mode. To do this, you can sideload the extension. This can be done by preparing the extension and loading it directly.
 
 1. `npm install -g vsce` to make sure you have vsce installed globally
@@ -38,7 +70,23 @@ After making changes to the extension, you might want to test it end to end inst
 
 For more information on using GistPad extension, follow the instructions for [getting started](https://github.com/vsls-contrib/gistpad#getting-started).
 
+## Submit your change for review
+
+Once you have coded, built, and tested your change, it's ready for review!
+
+- Your change should include tests (if possible).
+- Your commit message should be descriptive, provide context, and reference any issues it addresses. 
+
+Example:
+
+```bash
+Refactor func Foo.
+This will make the handling of <corner case>
+shorter and easier to test.
+
+For #nnnn
+```
+
 ## Attribution
 
-This documentation is adapted from the Microsoft / vscode-go, available at
-https://github.com/Microsoft/vscode-go/wiki/Building,-Debugging-and-Sideloading-the-extension-in-Visual-Studio-Code.
+This documentation is adapted from the Microsoft / vscode-go, available [here](https://github.com/golang/vscode-go/wiki/contributing#developing).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,6 @@ npm install
 code .
 ```
 
-You can now go to the Debug viewlet (`Ctrl+Shift+D`) and select `Run Extension (watch)` then hit run (`F5`).
-
-#### Lint
-
-You can run `npm run lint` on the command-line to check for lint errors in your program. You can also use the [TSLint](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) plugin to see errors as you code.
-
 ### Run
 
 To run the extension with your patch, open the Run view (`Ctrl+Shift+D` or `⌘+⇧+D`), select Launch Extension, and click Run (`F5`).
@@ -56,6 +50,10 @@ You can go to the Debug viewlet (`Ctrl+Shift+D`) and select `Run Extension (watc
 If you make subsequent edits in the codebase, you can reload (`Ctrl+R` or `⌘+R`) the `[Extension Development Host]` instance of VS Code, which will load the new code. The debugger will automatically reattach.
 
 In the original VS Code window, you can now add breakpoints which will be hit when you use any of the the plugin's features in the second window.
+
+#### Lint
+
+You can run `npm run lint` on the command-line to check for lint errors in your program. You can also use the [TSLint](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) plugin to see errors as you code.
 
 ## Sideloading the extension
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ GitHub Gists already allows you to star other user's gists, and when you do that
 
 ### Exporting to Repositories
 
-At some point, your code/notes might outgrow the feature set offered by Gists (e.g. when you want to start collaborating on the content with other developers). In that event, you can simply right-click the gist, and select the `Export to Repository` command in order to create a new GitHub repository, that contains the content of your gist. The created repo will be public or private, depending on the public/private state of the exported gist.
+At some point, your code/notes might outgrow the feature set offered by Gists (e.g. when you want to start collaborating on the content with other developers). In that event, you can simply right-click the gist, and select the `Export to Repository` command in order to create a new GitHub repository that contains the content of your gist. The created repo will be public or private, depending on the public/private state of the exported gist.
 
 ### Scratch Notes
 
-To make it easy to capture ephemeral/fleeting notes as you learn new things throughout the day, GistPad allows you to create "scratch notes" by clicking the `New scratch note...` command under the `Scratch Notes` node in the `Gists` tree (or running the `GistPad: New Scratch Note` command). A scratch note is simply a text document named be default for the time it was created.
+To make it easy to capture ephemeral/fleeting notes as you learn new things throughout the day, GistPad allows you to create "scratch notes" by clicking the `New scratch note...` command under the `Scratch Notes` node in the `Gists` tree (or running the `GistPad: New Scratch Note` command). A scratch note is simply a text document named by default for the time it was created.
 
 By default, scratch notes are Markdown documents, but you can customize that behavior (e.g. to create text/AsciiDoc/etc. files) by customizing the `GistPad > Scratch Notes: File Extension` setting. Furthermore, scratch notes are created per day, but you can customize this by setting the `GistPad > Scratch Notes: Directory Format` and `GistPad > Scratch Notes: File Format` settings.
 
@@ -130,7 +130,7 @@ To see what can be done with gists and [code swings](#codeswing), and to keep up
 
 ### GistLog
 
-In addition to using Gists to share code snippets/files, you can also use create a mini-blog with [GistLog](https://gistlog.co). In order to start blogging, simply run the `GistPad: New GistLog` command, which will create a new gthat includes two files, `blog.md` and `gistlog.yml`.
+In addition to using Gists to share code snippets/files, you can also create a mini-blog with [GistLog](https://gistlog.co). In order to start blogging, simply run the `GistPad: New GistLog` command, which will create a new mini-blog that includes two files, `blog.md` and `gistlog.yml`.
 
 ![GistLog](https://user-images.githubusercontent.com/116461/70856110-fdc3a900-1e8a-11ea-8e26-2c3917e11db0.gif)
 
@@ -160,7 +160,7 @@ In addition to creating a new repo "from scratch", you can also create a reposit
 
 By default, when you create/manage a repository, GistPad will assume you're interested in editing the `master` branch. However, when managing a repo, you can specify a different branch by appending `#<branch>` to the specified repo name (e.g. `vsls-contrib/gistpad#featureA`). When you're managing a non-master branch, the repo node in the `Repositories` tree will display the branch name.
 
-If at any time, you want to switch branches, simply right-click the repo node in the `Repositories` tree and select `Switch Branch`. This will let you pick one of the repo's remote branches, as well as create a new branch. When you're done with a branch, simply right-click the repo and select either `Delete Branch` or `Merge Branch`. The later will perform a "squash merge" against `master`. Using branches allows you to "batch" change sets together, and then apply them in a single/semantic commit.
+If at any time, you want to switch branches, simply right-click the repo node in the `Repositories` tree and select `Switch Branch`. This will let you pick one of the repo's remote branches, as well as create a new branch. When you're done with a branch, simply right-click the repo and select either `Delete Branch` or `Merge Branch`. The latter will perform a "squash merge" against `master`. Using branches allows you to "batch" change sets together, and then apply them in a single/semantic commit.
 
 ### Pasting Images
 
@@ -187,7 +187,7 @@ Additionally, to make it really simple to add a new wiki page, you can either ru
 
 <img width="75px" src="https://user-images.githubusercontent.com/116461/100490918-7c354d00-30d4-11eb-97d1-28035258656b.png" />
 
-> Note: While wikis add a "pages" abstraction layer on top of repos, they are still repos behind the scenes. As a result, if you like to add an arbitrary [file or directory](#files-and-directories) to your wiki, you can right-click it's node in the tree and select `Add New File`.
+> Note: While wikis add a "pages" abstraction layer on top of repos, they are still repos behind the scenes. As a result, if you like to add an arbitrary [file or directory](#files-and-directories) to your wiki, you can right-click its node in the tree and select `Add New File`.
 
 #### Daily Pages
 
@@ -205,7 +205,7 @@ Additionally, to make it really simple to open your "today page", you can either
 
 In order to create connections between pages, you can add `[[links]]` to a page. When you type `[[`, GistPad will display a completion list of the name of all existing pages. Furthermore, you can type a new topic/page title, and GistPad will automatically create that page for you.
 
-When a page includes `[[links]]`, they will be syntax highlighted, and you can hover over them to quickly see the context of the referenced page. Furthermore, you can `cmd+click` the link in order to directly jump to that page. If the page doesn't already exit, then `cmd+clicking` it will automatically create the page before opening it. This workflow makes it easy to author and navigate the set of pages within your wiki.
+When a page includes `[[links]]`, they will be syntax highlighted, and you can hover over them to quickly see the context of the referenced page. Furthermore, you can `cmd+click` the link in order to directly jump to that page. If the page doesn't already exist, then `cmd+clicking` it will automatically create the page before opening it. This workflow makes it easy to author and navigate the set of pages within your wiki.
 
 <img width="800px" src="https://user-images.githubusercontent.com/116461/87234714-96ba9400-c388-11ea-92c3-544d9a3bb633.png" />
 
@@ -217,11 +217,11 @@ Furthermore, when you open a page that contains backlinks, the set of backlinks 
 
 #### Embedding Files
 
-In addition to adding links to pages, it's sometimes valuable to embed the contents of another page directly into a note, so that you can easily read them together. To do this, you can use the `![[link]]` syntax, where you'll recieve auto-completion support just like regular links. When you use an embed link, the target page's contents will be displayed within the note whenever you view it's markdown preview.
+In addition to adding links to pages, it's sometimes valuable to embed the contents of another page directly into a note, so that you can easily read them together. To do this, you can use the `![[link]]` syntax, where you'll receive auto-completion support just like regular links. When you use an embed link, the target page's contents will be displayed within the note whenever you view its markdown preview.
 
 ## CodeSwing
 
-If you're building web applications, and want to create a quick playground environment in order to experiment with HTML, CSS or JavaScript (or [Sass/SCSS, Less, Pug and TypeScript](#additional-language-support)), you can install the [CodeSwing extension](https://aka.ms/codeswing), in order to have a CodePen-like web experience, integrated into VS Code. GistPad provides an integration with CodeSwing, and so once it's installed, you can right-click the `Your Gists` node in the `GistPad` tree and select `New CodeSwing` or `New Secret CodeSwing`. This will create a new gist, seeded with the selected template fiels, and then provide you with a live preview Webview, so that you can iterate on the code and visually see how it behaves.
+If you're building web applications, and want to create a quick playground environment in order to experiment with HTML, CSS or JavaScript (or [Sass/SCSS, Less, Pug and TypeScript](#additional-language-support)), you can install the [CodeSwing extension](https://aka.ms/codeswing), in order to have a CodePen-like web experience, integrated into VS Code. GistPad provides an integration with CodeSwing, and so once it's installed, you can right-click the `Your Gists` node in the `GistPad` tree and select `New CodeSwing` or `New Secret CodeSwing`. This will create a new gist, seeded with the selected template files, and then provide you with a live preview Webview, so that you can iterate on the code and visually see how it behaves.
 
 When you create a new swing, you'll be asked to select a template, which is simply a way to get started quickly, using the libraries and languages you intend to use (e.g. React.js, Vue.js). Since the swing is backed by a Gist, your changes are saved and shareable with your friends. Additionally, as you find other swings that you'd like to use, simply fork them and create your own swings. That way, you can use Gists as "templates" for swing environments, and collaborate on them with others just like you would any other gist. When you're done with a swing, simply close the preview window and all other documents will be automatically closed. If you no longer need the swing, then delete it just like any other gist 👍
 
@@ -300,7 +300,7 @@ In addition to the `Gists` view, this extension also provides the following comm
 
 - `Gistpad > Images: Paste Type`: Specifies the method to use when pasting an image into a gist file. Can be set to one of the following values:
 
-  - `file` _(default)_: The pasted image is uploaded as a `.png` to the gist, and a reference is added to file it's pasted into.
+  - `file` _(default)_: The pasted image is uploaded as a `.png` to the gist, and a reference is added to the file it's pasted into.
   - `base64`: The pasted image is base64-encoded and then embedded into the gist file.
 
 - `Gistpad > Images: Upload Directory Name`: Specifies the name of the directory to upload images to. Defaults to `images`.

--- a/README.md
+++ b/README.md
@@ -316,3 +316,17 @@ In addition to the `Gists` view, this extension also provides the following comm
 - `GistPad > Showcase URL` - Specifies the URL to use when displaying the showcase entry. This allows teams/classrooms/etc. to create their own showcase and share it amongst themselves.
 
 - `GistPad > Tracing > Enable Output Channel` - When enabled, creates an Output trace channel at VSCode startup.
+
+### Reporting Bugs and Issues
+
+If you believe you have found a bug, try searching our open [Github Issues](https://github.com/lostintangent/gistpad/issues) to see if anyone has posted about a similar problem. If you're confident it's a new bug that has not been addressed, [create a new issue](https://github.com/lostintangent/gistpad/issues/new/choose). Be sure to include as much information as possible so we can reproduce the bug.
+
+### Contributing
+
+Thank you for your interest in contributing to Gistpad! We welcome all contributions to update, maintain, and improve the project. 
+
+> #### [Please follow these steps to contribute](CONTRIBUTING.md).
+
+### License
+
+The content of this repository is licensed under the [MIT License](LICENSE.md) license.


### PR DESCRIPTION
I added to these sections to encourage other developers to add new features, fixes, and updates to the project by clarifying the process for contributing.

1. README.md:
- Added Contributing section
- Added License section
- Added Report Bugs/Issues Section
- Addressed typos/grammar and clarity. 

2. CONTRIBUTING
- Updated formatting
- Added Before you start coding section
- Added Debug/Run section
- Added Submit your changes Section

3. CODE OF CONDUCT.md
- Added CoC section 
