### PR TITLE
Add Manual sync feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The `Copy File to Gist` command is also available on the editor tab's context me
 In addition to the commands added to the editor context menu, GistPad also contributes the following commands to the editor's title bar menu (click the `...` in the upper right section of an editor window):
 
 - `Rename File` - Allows you to rename the current file.
-- `Sync Gist` - Sync the current gist file to GitHub. Only available when `gistpad.autoSyncWhenSave` is disabled.
+- `Sync Gist` - Sync the current gist file to GitHub. Only available when `gistpad.syncOnSave` is disabled.
 
 ## Contributed Commands (Command Palette)
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ The `Copy File to Gist` command is also available on the editor tab's context me
 In addition to the commands added to the editor context menu, GistPad also contributes the following commands to the editor's title bar menu (click the `...` in the upper right section of an editor window):
 
 - `Rename File` - Allows you to rename the current file.
+- `Sync Gist` - Sync the current gist file to GitHub. Only available when `gistpad.autoSyncWhenSave` is disabled.
 
 ## Contributed Commands (Command Palette)
 
@@ -303,3 +304,5 @@ In addition to the `Gists` view, this extension also provides the following comm
 - `GistPad > Showcase URL` - Specifies the URL to use when displaying the showcase entry. This allows teams/classrooms/etc. to create their own showcase and share it amongst themselves.
 
 - `GistPad > Tracing > Enable Output Channel` - When enabled, creates an Output trace channel at VSCode startup.
+
+- `GistPad > Auto Sync When Save` - Specifies whether or not to enable the auto sync feature when saving a file. Consider disabling this option when VS Code's `files.autoSave` is enabled to prevent frequent syncing operations. Defaults to `true`.

--- a/package.json
+++ b/package.json
@@ -120,10 +120,10 @@
           "type": "boolean",
           "description": "Specifies whether or not to enable the output channel for tracing."
         },
-        "gistpad.autoSyncWhenSave": {
+        "gistpad.syncOnSave": {
           "default": true,
           "type": "boolean",
-          "description": "Specifies whether or not to enable the auto sync feature when saving a file. By default, this is enabled."
+          "description": "Specifies whether to automatically sync a file with GitHub when saving it. Defaults to true."
         }
       }
     },
@@ -541,7 +541,7 @@
         "title": "View Forks"
       },
       {
-        "command": "gistpad.syncGist",
+        "command": "gistpad.syncGistFile",
         "title": "Sync Gist",
         "icon": "$(sync)"
       }
@@ -1376,8 +1376,8 @@
           "when": "resourceScheme == repo"
         },
         {
-          "command": "gistpad.syncGist",
-          "when": "resourceScheme == gist && !gistpad.autoSyncWhenSave",
+          "command": "gistpad.syncGistFile",
+          "when": "resourceScheme == gist && !gistpad.syncOnSave",
           "group": "navigation@1"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -119,6 +119,11 @@
           "default": false,
           "type": "boolean",
           "description": "Specifies whether or not to enable the output channel for tracing."
+        },
+        "gistpad.autoSyncWhenSave": {
+          "default": true,
+          "type": "boolean",
+          "description": "Specifies whether or not to enable the auto sync feature when saving a file. By default, this is enabled."
         }
       }
     },
@@ -534,6 +539,11 @@
       {
         "command": "gistpad.viewForks",
         "title": "View Forks"
+      },
+      {
+        "command": "gistpad.syncGist",
+        "title": "Sync Gist",
+        "icon": "$(sync)"
       }
     ],
     "menus": {
@@ -1364,6 +1374,11 @@
         {
           "command": "gistpad.renameRepositoryFile",
           "when": "resourceScheme == repo"
+        },
+        {
+          "command": "gistpad.syncGist",
+          "when": "resourceScheme == gist && !gistpad.autoSyncWhenSave",
+          "group": "navigation@1"
         }
       ],
       "editor/title/context": [

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -122,7 +122,7 @@ async function newGistInternal(isPublic: boolean = true, description: string = "
   descriptionInputBox.show();
 }
 
-async function syncGistInternal() {
+async function syncGistFileInternal() {
   await ensureAuthenticated();
   
   let error: Error | undefined;
@@ -134,7 +134,7 @@ async function syncGistInternal() {
   await window.withProgress(
     {
       location: ProgressLocation.Notification,
-      title: "Uploading to GitHub Gist..."
+      title: "Syncing changes with gist..."
     },
     async () => {
       try {
@@ -753,6 +753,6 @@ export async function registerGistCommands(context: ExtensionContext) {
   );
   
   context.subscriptions.push(
-    commands.registerCommand(`${EXTENSION_NAME}.syncGist`, syncGistInternal)
+    commands.registerCommand(`${EXTENSION_NAME}.syncGistFile`, syncGistFileInternal)
   );
 }

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -126,6 +126,10 @@ async function syncGistInternal() {
   await ensureAuthenticated();
   
   let error: Error | undefined;
+  const activeEditor = window.activeTextEditor;
+  if (!activeEditor) {
+    throw new Error("No active editor");
+  }
   
   await window.withProgress(
     {
@@ -134,11 +138,6 @@ async function syncGistInternal() {
     },
     async () => {
       try {
-        const activeEditor = window.activeTextEditor;
-        if (!activeEditor) {
-          throw new Error("No active editor");
-        }
-        
         const uri = activeEditor.document.uri;
         const { gistId } = getGistDetailsFromUri(uri);
         
@@ -157,6 +156,8 @@ async function syncGistInternal() {
         ]);
 
         await refreshGist(gistId);
+        
+        store.unsyncedFiles.delete(uri.toString());
       } catch (err) {
         error = err as Error;
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export function get(key: "scratchNotes.show"): boolean;
 export function get(key: "showcaseUrl"): string;
 export function get(key: "comments.showThread"): string;
 export function get(key: "output"): boolean;
+export function get(key: "autoSyncWhenSave"): boolean;
 export function get(key: any) {
   const extensionConfig = vscode.workspace.getConfiguration(CONFIG_SECTION);
   return extensionConfig.get(key);

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export function get(key: "scratchNotes.show"): boolean;
 export function get(key: "showcaseUrl"): string;
 export function get(key: "comments.showThread"): string;
 export function get(key: "output"): boolean;
-export function get(key: "autoSyncWhenSave"): boolean;
+export function get(key: "syncOnSave"): boolean;
 export function get(key: any) {
   const extensionConfig = vscode.workspace.getConfiguration(CONFIG_SECTION);
   return extensionConfig.get(key);

--- a/src/fileSystem/index.ts
+++ b/src/fileSystem/index.ts
@@ -73,8 +73,7 @@ export class GistFileSystemProvider implements FileSystemProvider {
           continue; 
         }
 
-        const filename = path.basename(Uri.parse(uri).path);
-        const { gistId } = getGistDetailsFromUri(Uri.parse(uri));
+        const { gistId, file: filename } = getGistDetailsFromUri(input.uri);
 
         const result = await window.showWarningMessage(
           `"${filename}" has changes that haven't been synced.`,

--- a/src/fileSystem/index.ts
+++ b/src/fileSystem/index.ts
@@ -77,13 +77,13 @@ export class GistFileSystemProvider implements FileSystemProvider {
         const { gistId } = getGistDetailsFromUri(Uri.parse(uri));
 
         const result = await window.showWarningMessage(
-          `${filename} has changes that have not been synced to GitHub. Do you want to sync them now?`,
+          `"${filename}" has changes that haven't been synced.`,
           { modal: true },
-          "Yes", 
+          "Sync Changes", 
           "Discard Changes"
         );
 
-        if (result === "Yes") {
+        if (result === "Sync Changes") {
           const document = workspace.textDocuments.find(doc => doc.uri.toString() === uri);
           if (document) {
             try {
@@ -437,8 +437,8 @@ export class GistFileSystemProvider implements FileSystemProvider {
       const file = await this.getFileFromUri(uri);
       const type = file ? FileChangeType.Changed : FileChangeType.Created;
 
-      const autoSyncEnabled = config.get("autoSyncWhenSave");
-      if (!autoSyncEnabled && type === FileChangeType.Changed) {
+      const syncOnSaveEnabled = config.get("syncOnSave");
+      if (!syncOnSaveEnabled && type === FileChangeType.Changed) {
         this.store.unsyncedFiles.add(uri.toString());
         this._onDidChangeFile.fire([{ type, uri }]);
         return;

--- a/src/fileSystem/index.ts
+++ b/src/fileSystem/index.ts
@@ -16,6 +16,7 @@ import {
   window,
   workspace
 } from "vscode";
+import * as config from "../config";
 import {
   DIRECTORY_SEPARATOR,
   ENCODED_DIRECTORY_SEPARATOR,
@@ -385,6 +386,12 @@ export class GistFileSystemProvider implements FileSystemProvider {
     } else {
       const file = await this.getFileFromUri(uri);
       const type = file ? FileChangeType.Changed : FileChangeType.Created;
+
+      const autoSyncEnabled = config.get("autoSyncWhenSave");
+      if (!autoSyncEnabled && type === FileChangeType.Changed) {
+        this._onDidChangeFile.fire([{ type, uri }]);
+        return;
+      }
 
       return new Promise((resolve) => {
         this._pendingWrites.next({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -116,6 +116,7 @@ export interface Store {
   starredGists: Gist[];
   canCreateRepos: boolean;
   canDeleteRepos: boolean;
+  unsyncedFiles: Set<string>;
 }
 
 export const store: Store = observable({
@@ -132,5 +133,6 @@ export const store: Store = observable({
   groupType: GroupType.none,
   starredGists: [],
   canCreateRepos: false,
-  canDeleteRepos: false
+  canDeleteRepos: false,
+  unsyncedFiles: new Set<string>()
 });


### PR DESCRIPTION
Hi, JC.

**This PR fixes Issue #276 and #212**

**Description of the PR**:
This PR enhances the Gist synchronization mechanism by implementing the following features:

1. **Manual Sync Improvements**:
   - Added a warning prompt when closing tabs with unsynced changes
   - Users can choose to sync changes or discard them before closing
   - Users can manually upload files at the editor title of the opened gist

2. **File Sync Status Tracking**:
   - Implemented a new `unsyncedFiles` tracking system in the Store
   - Files are automatically marked as unsynced when changes are made and saved without auto-sync
   - Sync status is cleared after successful synchronization

3. **Auto-sync Configuration**:
   - Added configuration option `autoSyncWhenSave` to control sync behavior

**Additional context**:
This enhancement improves the user experience by:
- Preventing accidental loss of changes when closing files
- Reducing unnecessary API calls through configurable auto-sync behavior
